### PR TITLE
mechanize more typescript opinions

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,12 +195,10 @@ module.exports = {
       },
     ],
 
-    // Allow interfaces that extend other interfaces (useful for class types).
-    // These are mostly used in our system for Sequelize type definitions (coming soon...).
-    '@typescript-eslint/no-empty-interface': [
+    '@typescript-eslint/no-empty-object-type': [
       'error',
       {
-        allowSingleExtends: true, // Allow interfaces that extend other interfaces (useful for class types)
+        allowSingleExtends: true, // Allow types that extend other types
       },
     ],
   },


### PR DESCRIPTION
following discussions about typescript standards, this code adds warnings for the following patterns:
- inline exports -- strongly prefer exports at end of file
- prefer `const` functions over `function` declarations -- this has been our preference at the company for years, we should encode it
- prefer `type` instead of `interface` for type definitions: more on this at the education session, but in brief, `type` is much much more capable unless you are declaring javascript classes. this change disallows empty interfaces and prefers `type` for pretty much everything, warning otherwise.