### PR TITLE
feat: enforce no-nested-ternary as error

### DIFF
--- a/src/node.config.cjs
+++ b/src/node.config.cjs
@@ -23,6 +23,7 @@ const rules = {
   'no-continue': 'off',
   'no-bitwise': 'off',
   'no-cond-assign': 'off',
+  'no-nested-ternary': 'error',
   'no-await-in-loop': 'off',
   'no-case-declarations': 'off',
   indent: 'off',

--- a/src/react.config.cjs
+++ b/src/react.config.cjs
@@ -19,6 +19,7 @@ const rules = {
   'no-continue': 'off',
   'no-bitwise': 'off',
   'no-cond-assign': 'off',
+  'no-nested-ternary': 'error',
   'no-await-in-loop': 'off',
   'no-case-declarations': 'off',
   indent: 'off',


### PR DESCRIPTION
## Summary
- Adds `no-nested-ternary: error` to both the node and react ESLint configs